### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/netrc/braggingRights.png?label=ready&title=Ready)](https://waffle.io/netrc/braggingRights?utm_source=badge)
 
 
 Tracking North American cities cumulative sports championships...


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/netrc/braggingRights

This was requested by a real person (user netrc) on waffle.io, we're not trying to spam you.